### PR TITLE
Fix link to WorldWindLabs

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,7 +6,7 @@
                 <a href="/"><h3 class="text-center">Home</h3></a>
             </div>
             <div class="col-md-2 fh5co-widget">
-                <a href="https://github.com/NASAWorldWindResearch"><h3 class="text-center">Apps</h3></a>
+                <a href="https://github.com/WorldWindLabs"><h3 class="text-center">Apps</h3></a>
             </div>
             <div class="col-md-2 fh5co-widget">
                 <a href="https://github.com/NASAWorldWind"><h3 class="text-center">Source Code</h3></a>


### PR DESCRIPTION
Fix link to reflect changing "WorldWind Research" to "WorldWindLabs"